### PR TITLE
fix sometimes appearing sleeping issues on the kobo nia

### DIFF
--- a/etc/init.d/sleep_standby.sh
+++ b/etc/init.d/sleep_standby.sh
@@ -76,6 +76,9 @@ if [ "$(cat /sys/class/net/${WIFI_DEV}/operstate)" == "up" ]; then
 	fi
 	rmmod "${WIFI_MODULE}" 2> /dev/null
 	rmmod "${SDIO_WIFI_PWR_MODULE}" 2> /dev/null
+elif [ "${DEVICE}" == "n306" ]; then
+	rmmod "${WIFI_MODULE}" 2> /dev/null
+	rmmod "${SDIO_WIFI_PWR_MODULE}" 2> /dev/null
 fi
 
 echo "false" > /kobo/inkbox/remount

--- a/etc/init.d/wake_standby.sh
+++ b/etc/init.d/wake_standby.sh
@@ -76,6 +76,9 @@ if grep -q "true" /run/was_connected_to_wifi; then
 	PASSPHRASE=$(cat /data/config/17-wifi_connection_information/passphrase)
 	/usr/local/bin/wifi/connect_to_network.sh "${ESSID}" "${PASSPHRASE}"
 	rm -f /run/was_connected_to_wifi
+elif [ "${DEVICE}" == "n306" ]; then
+	insmod "${WIFI_MODULE}"
+	insmod "${SDIO_WIFI_PWR_MODULE}"
 fi
 
 sleep 1


### PR DESCRIPTION
The device will sometimes not go to sleep when the modules are loaded, even if the interface is down