### PR TITLE
possible fix for onboard mounting read only once

### DIFF
--- a/etc/init.d/onboard_mount
+++ b/etc/init.d/onboard_mount
@@ -8,6 +8,7 @@ depend() {
 
 start() {
 	ebegin "Mounting onboard storage filesystem"
+	fsck.fat -y -V -n /opt/storage/onboard
 	losetup /dev/loop0 /opt/storage/onboard
 	mount /dev/loop0 /data/onboard -o nosuid,noexec,nodev,uid=1000,gid=1000
 	eend $?


### PR DESCRIPTION
I have force rebooted a few times the device, then the one time onboard was mounted read only, after a few more reboots it repaired itself. Then i manually runned fsck and it detected some errors. this should fix such situations